### PR TITLE
fix for harvest after migration

### DIFF
--- a/contracts/StrategyUniswapPairPickle.sol
+++ b/contracts/StrategyUniswapPairPickle.sol
@@ -145,9 +145,10 @@ contract StrategyUniswapPairPickle is BaseStrategy {
      * are sustained for long periods of time.
      */
     function prepareReturn() internal override {
+        reserve = want.balanceOf(address(this));
         PickleChef(chef).deposit(pid, 0);
         uint _amount = IERC20(reward).balanceOf(address(this));
-        if (_amount == 0) return;
+        if (_amount < 1 gwei) return;
         swap(reward, token0, _amount / 2);
         _amount = IERC20(reward).balanceOf(address(this));
         swap(reward, token1, _amount);
@@ -162,6 +163,7 @@ contract StrategyUniswapPairPickle is BaseStrategy {
      * be 0, and you should handle that scenario accordingly.
      */
     function adjustPosition() internal override {
+        reserve = 0;
         uint _amount = want.balanceOf(address(this));
         if (_amount == 0) return;
         // stake lp tokens in pickle jar

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -2,6 +2,15 @@ def test_migration(chain, vault, strategy, succ_strategy, gov):
     chain.mine(100)
     strategy.harvest()
     before = strategy.estimatedTotalAssets().to('ether')
+    print('estimatedTotalAssets before', before)
+    print('pricePerShare', vault.pricePerShare().to('ether'))
     vault.migrateStrategy(strategy, succ_strategy, {'from': gov})
     assert strategy.estimatedTotalAssets().to('ether') == 0
     assert succ_strategy.estimatedTotalAssets().to('ether') >= before
+    print('estimatedTotalAssets migrate', succ_strategy.estimatedTotalAssets().to('ether'))
+    print('pricePerShare', vault.pricePerShare().to('ether'))
+    succ_strategy.harvest()
+    print('estimatedTotalAssets harvest', succ_strategy.estimatedTotalAssets().to('ether'))
+    print('pricePerShare', vault.pricePerShare().to('ether'))
+    assert vault.pricePerShare() < '1.5 ether'
+    assert succ_strategy.estimatedTotalAssets() >= before


### PR DESCRIPTION
## Discussion

Sam, [Oct 29, 2020 at 12:04:13]:
> @banteg - i've worked out why you got the 1.9 price per share.
> 
> 1 - you migrate. which converts balance into want and sends it to new contract
> 
> 2 - you call harvest. But strategy has balance of want that it is not expecting and prepareReturn doesn't touch the want balance. So it calls report with your full want balance. Vault now thinks your full balance is profit so adds it to your totaldebt
> 
Sam, [Oct 29, 2020 at 12:26:29 (Oct 29, 2020 at 13:33:08)]:
> the reason why the next harvest failed:
> 
> when you reported your full balance as profit vault checked to see how much your debt limit should be. 
> 
> It does this by adding the current debtamount to number of blocks since last report * rate limit. 
> 
> Your rate limit is very small. So vault decided you were pretty much at your debt limit and withdrew most of your want
> 
> Next time harvest is called you claimed pickle rewards on the tiny amount you had staked. as this was so low it failed due to be rounded down to 0 on the second part your second transaction
> 
Sam, [Oct 29, 2020 at 12:30:54 (Oct 29, 2020 at 12:41:48)]:
> My suggestions:
>  -at the beginning of prepare return set reserves as the current want balance. This will stop it being reported as profit. reset reserves to 0 in adjust position
> - in prepare return set a minimun use a variable to set a minumun amount of pickle that is worth claiming before you sell it.
> - use a much higher rate limit
> 
Carlos Sessa, [Oct 29, 2020 at 14:41:56 (Oct 29, 2020 at 14:42:53)]:
> @defisam h/t! I also felt into a similar pitfall by not managing reserves correctly. Withdraw sends to the vault all want, not just the amount asked, so if reserve is not set correctly there are dragons
> 
Carlos Sessa, [Oct 29, 2020 at 14:48:37]:
> Yesterday talking with @fubuloubu we discussed the possibility of changing the api to avoid dealing with base strategy internal variables

## Test case
```
tests/test_migration.py::test_migration[config2] RUNNING
estimatedTotalAssets before 40775.418565413919973653
pricePerShare 1.000000000000000000
estimatedTotalAssets migrate 40775.418565413919999999
pricePerShare 1.000000000000000000
estimatedTotalAssets harvest 0E-18
pricePerShare 1.904761904761904761
tests/test_migration.py::test_migration[config2] FAILED
```
